### PR TITLE
chore: use yaml for nicer formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ span {
 
 You can either change the settings inside your VSCode (`eufemia.x`) or in a config file (`.vscode-eufemia.json`) you commit to your repository. The config file can be placed on every relative directory level (mono-repo support). This way, everyone on the team can use the same settings. Above the default options:
 
-```json
+```yaml
 {
   "rootFontSize": 16,
   "fixedDigits": 4,


### PR DESCRIPTION

```yaml
{
  "rootFontSize": 16,
  "fixedDigits": 4,
  "autoRemovePrefixZero": true,
  "ingoresViaCommand": [],
  "addMark": false,
  "hover": "onlyMark" /* disabled | always | onlyMark */,
  "ingores": [],
  "languages": [
    "css",
    "scss",
    "sass",
    "javascriptreact",
    "typescriptreact",
    "javascript",
    "typescript"
  ],
  "spacingProperties": [
    "margin",
    "padding",
    "top",
    "bottom",
    "left",
    "right",
    "inset"
  ],
  "currentLine": "show" /* disabled | show */,
  "calcMethodName": "calc"
}
```
